### PR TITLE
use range constructs that build on Go 1.3

### DIFF
--- a/match/max.go
+++ b/match/max.go
@@ -15,7 +15,7 @@ func NewMax(l int) Max {
 
 func (self Max) Match(s string) bool {
 	var l int
-	for range s {
+	for _ = range s {
 		l += 1
 		if l > self.Limit {
 			return false

--- a/match/min.go
+++ b/match/min.go
@@ -15,7 +15,7 @@ func NewMin(l int) Min {
 
 func (self Min) Match(s string) bool {
 	var l int
-	for range s {
+	for _ = range s {
 		l += 1
 		if l >= self.Limit {
 			return true

--- a/match/row.go
+++ b/match/row.go
@@ -43,7 +43,7 @@ func (self Row) matchAll(s string) bool {
 
 func (self Row) lenOk(s string) bool {
 	var i int
-	for range s {
+	for _ = range s {
 		i++
 		if i >= self.RunesLength {
 			return true


### PR DESCRIPTION
While `for range s` is neat, it doesn't compile on Go 1.3. `for _ = range s` does and is functionally equivalent.

(I've recently added this as a dependency for Syncthing, and Syncthing currently builds with Go 1.3 and upwards.)