### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
-sudo: false
-
 language: go
-
 go:
-  - 1.7
-  - 1.8
-  - 1.9
+  - "1.7.X"
+  - "1.8.X"
+  - "1.9.X"
+  - "1.10.X"
+  - master
+
+matrix:
+  allow_failures:
+    - go: master
+fast_finish: true
 
 script:
   - go test -v ./...


### PR DESCRIPTION
- Add go 1.10 to tests
- Run the newest version, e.g. 0.10.3 instead of 0.10
- Run tests on go:master