### PR TITLE
Fixed vet error 'syntax/ast/parser.go:86: unreachable code'

### DIFF
--- a/syntax/ast/parser.go
+++ b/syntax/ast/parser.go
@@ -83,7 +83,6 @@ func parserMain(tree *Node, lex Lexer) (parseFn, *Node, error) {
 			return nil, tree, fmt.Errorf("unexpected token: %s", token)
 		}
 	}
-	return nil, tree, fmt.Errorf("unknown error")
 }
 
 func parserRange(tree *Node, lex Lexer) (parseFn, *Node, error) {


### PR DESCRIPTION
This PR removes an unreachable line of code that is flagged by `go tool vet .`:
```
$ go tool vet .
syntax/ast/parser.go:86: unreachable code
```

Personally, I prefer the catch-all return statement and I think it's annoying that `vet` doesn't like it, but in any case, this PR removes that line since the `switch...default(return)` makes it unreachable, and therefore untestable.