### PR TITLE
fix: add bounds check in Row.matchAll to prevent slice panic

### DIFF
--- a/match/row.go
+++ b/match/row.go
@@ -31,11 +31,12 @@ func (self Row) matchAll(s string) bool {
 			}
 		}
 
-		if i < length || !m.Match(s[idx:idx+next+1]) {
+		end := idx + next + 1
+		if i < length || end > len(s) || !m.Match(s[idx:end]) {
 			return false
 		}
 
-		idx += next + 1
+		idx = end
 	}
 
 	return true


### PR DESCRIPTION
Fixes #59

## Problem

`Row.matchAll` computes `idx+next+1` as the slice end without checking if it exceeds `len(s)`. With certain compiled patterns, this causes a panic:

```go
gg, _ := glob.Compile("/{a{*.json{", '/')`
gg.Match("/a/b/c/d/e/foo.json")
// panic: runtime error: slice bounds out of range [:6] with length 5
```

## Fix

Add a bounds check before slicing:

```go
end := idx + next + 1
if i < length || end > len(s) || !m.Match(s[idx:end]) {
    return false
}
```