### PR TITLE
fix: prevent slice bounds panic in Row.matchAll

### DIFF
--- a/match/row.go
+++ b/match/row.go
@@ -31,11 +31,20 @@ func (self Row) matchAll(s string) bool {
 			}
 		}
 
-		if i < length || !m.Match(s[idx:idx+next+1]) {
+		if i < length {
 			return false
 		}
 
-		idx += next + 1
+		end := idx + next + 1
+		if end > len(s) {
+			return false
+		}
+
+		if !m.Match(s[idx:end]) {
+			return false
+		}
+
+		idx = end
 	}
 
 	return true


### PR DESCRIPTION
Fixes #59

## Problem

`Row.matchAll` panics with `slice bounds out of range` for certain glob patterns:

```go
gg, _ := glob.Compile("/{a{*.json{", '/')
gg.Match("/a/b/c/d/e/foo.json")  // PANIC: slice bounds out of range
```

The computed slice end `idx + next + 1` can exceed the string length when the pattern produces a `Row` with `RunesLength` larger than the actual string being matched.

## Fix

Add explicit bounds checks before slicing:
1. Return `false` early if fewer runes are available than needed
2. Return `false` if the computed end index exceeds string length

All existing tests pass, plus the reproducer from the issue now returns `false` instead of panicking.