### PR TITLE
Fix non-constant Fprintf format strings

### DIFF
--- a/match/debug/debug.go
+++ b/match/debug/debug.go
@@ -27,7 +27,7 @@ func graphviz_internal(m match.Matcher, id string) string {
 			default:
 				sub := fmt.Sprintf("%x", rand.Int63())
 				fmt.Fprintf(buf, `"%s"->"%s";`, id, sub)
-				fmt.Fprintf(buf, graphviz_internal(n, sub))
+				fmt.Fprint(buf, graphviz_internal(n, sub))
 			}
 		}
 
@@ -35,7 +35,7 @@ func graphviz_internal(m match.Matcher, id string) string {
 		fmt.Fprintf(buf, `"%s"[label="AnyOf"];`, id)
 		for _, m := range matcher.Matchers {
 			rnd := rand.Int63()
-			fmt.Fprintf(buf, graphviz_internal(m, fmt.Sprintf("%x", rnd)))
+			fmt.Fprint(buf, graphviz_internal(m, fmt.Sprintf("%x", rnd)))
 			fmt.Fprintf(buf, `"%s"->"%x";`, id, rnd)
 		}
 
@@ -43,7 +43,7 @@ func graphviz_internal(m match.Matcher, id string) string {
 		fmt.Fprintf(buf, `"%s"[label="EveryOf"];`, id)
 		for _, m := range matcher.Matchers {
 			rnd := rand.Int63()
-			fmt.Fprintf(buf, graphviz_internal(m, fmt.Sprintf("%x", rnd)))
+			fmt.Fprint(buf, graphviz_internal(m, fmt.Sprintf("%x", rnd)))
 			fmt.Fprintf(buf, `"%s"->"%x";`, id, rnd)
 		}
 


### PR DESCRIPTION
Summary:
- Use `fmt.Fprint` when writing already formatted Graphviz fragments.
- This satisfies current Go vet without changing output.

Testing:
- `GOPATH=/tmp/upstream-gopath GO111MODULE=off go test github.com/gobwas/glob/match/debug`