### PR TITLE
fix: AnyOf.Len returns -1 when any matcher has unknown length

### DIFF
--- a/glob_test.go
+++ b/glob_test.go
@@ -154,6 +154,16 @@ func TestGlob(t *testing.T) {
 
 		glob(true, pattern_alternatives_combine_lite, fixture_alternatives_combine_lite),
 
+		// Two-alternative brace expansion with variable-length matchers (regression for
+		// AnyOf.Len incorrectly returning a non-(-1) length when one matcher has unknown
+		// length and another has a known length).
+		glob(true, "{**/daxing,daxing}/**/*dev*.yaml", "playground/daxing/generated/dev.yaml", '/'),
+		glob(true, "{**/daxing,daxing}/**/*dev*.yaml", "daxing/generated/dev.yaml", '/'),
+		glob(false, "{**/daxing,daxing}/**/*dev*.yaml", "playground/other/generated/dev.yaml", '/'),
+		glob(true, "{**/a,a}", "x/y/a", '/'),
+		glob(true, "{**/a,a}", "a", '/'),
+		glob(false, "{**/a,a}", "x/y/b", '/'),
+
 		glob(true, pattern_prefix, fixture_prefix_suffix_match),
 		glob(false, pattern_prefix, fixture_prefix_suffix_mismatch),
 

--- a/match/any_of.go
+++ b/match/any_of.go
@@ -59,17 +59,16 @@ func (self AnyOf) Index(s string) (int, []int) {
 
 func (self AnyOf) Len() (l int) {
 	l = -1
-	for _, m := range self.Matchers {
+	for i, m := range self.Matchers {
 		ml := m.Len()
-		switch {
-		case l == -1:
+		if ml == -1 {
+			return -1
+		}
+		if i == 0 {
 			l = ml
 			continue
-
-		case ml == -1:
-			return -1
-
-		case l != ml:
+		}
+		if l != ml {
 			return -1
 		}
 	}

--- a/match/any_of_test.go
+++ b/match/any_of_test.go
@@ -5,6 +5,55 @@ import (
 	"testing"
 )
 
+func TestAnyOfLen(t *testing.T) {
+	for id, test := range []struct {
+		matchers Matchers
+		want     int
+	}{
+		{
+			// all matchers have the same known length
+			Matchers{NewText("abc"), NewText("xyz")},
+			3,
+		},
+		{
+			// matchers have different known lengths
+			Matchers{NewText("ab"), NewText("xyz")},
+			-1,
+		},
+		{
+			// first matcher has unknown length, second has known length
+			Matchers{NewSuffix("/daxing"), NewText("daxing")},
+			-1,
+		},
+		{
+			// first matcher has known length, second has unknown length
+			Matchers{NewText("daxing"), NewSuffix("/daxing")},
+			-1,
+		},
+		{
+			// all matchers have unknown length
+			Matchers{NewSuffix("/a"), NewPrefix("b/")},
+			-1,
+		},
+		{
+			// single matcher with known length
+			Matchers{NewText("hello")},
+			5,
+		},
+		{
+			// single matcher with unknown length
+			Matchers{NewSuffix("hello")},
+			-1,
+		},
+	} {
+		anyOf := NewAnyOf(test.matchers...)
+		got := anyOf.Len()
+		if got != test.want {
+			t.Errorf("#%d AnyOf.Len() = %d, want %d", id, got, test.want)
+		}
+	}
+}
+
 func TestAnyOfIndex(t *testing.T) {
 	for id, test := range []struct {
 		matchers Matchers


### PR DESCRIPTION
## Summary

AnyOf.Len had a logical error: it used -1 as both the uninitialised sentinel and the unknown-length return value. When the first matcher returned -1 (unknown length), l was set to -1, and on the next iteration the case l == -1 branch matched again, overwriting l with the second matcher's concrete length. This silently reported a fixed length for an AnyOf even though one of its alternatives had variable length.

This caused glueMatchersAsRow to include an AnyOf in a Row, which then called Row.matchAll expecting the AnyOf to consume exactly Len() runes. That excluded alternatives needing a different number of bytes, breaking two-alternative brace patterns such as {**/daxing,daxing}/**/*.yaml.

Fixes #66

## Changes

- match/any_of.go: return -1 immediately when any matcher reports -1; use the loop index to distinguish the uninitialised (i==0) case from the unknown-length case
- match/any_of_test.go: add TestAnyOfLen table-driven tests covering all relevant combinations
- glob_test.go: add regression tests for two-alternative brace expansion with variable-length matchers

## Testing

All existing tests continue to pass. New tests cover:

- AnyOf.Len when one or more matchers have unknown length
- AnyOf.Len when all matchers share the same known length
- AnyOf.Len when matchers have different known lengths
- End-to-end matching of two-alternative brace patterns ({**/daxing,daxing}/**/*dev*.yaml)