### PR TITLE
fix(match): AnyOf.Len keeps variable length when first alt is variable

### DIFF
--- a/glob_test.go
+++ b/glob_test.go
@@ -529,3 +529,23 @@ func BenchmarkPrefixSuffixRegexpMismatch(b *testing.B) {
 		_ = m.Match(f)
 	}
 }
+
+func TestBraceTwoAlternativesWithSuper(t *testing.T) {
+	// Regression: exactly two brace alternatives where the first is variable
+	// length used to report a fixed AnyOf.Len and fail to match.
+	input := "playground/daxing/generated/dev.yaml"
+	for id, pattern := range []string{
+		"{**/daxing}/**/*dev*.yaml",
+		"{**/daxing,daxing}/**/*dev*.yaml",
+		"{**/daxing,daxing,x}/**/*dev*.yaml",
+		"{**/daxing,daxing,x,y}/**/*dev*.yaml",
+	} {
+		g, err := Compile(pattern)
+		if err != nil {
+			t.Fatalf("#%d compile %q: %v", id, pattern, err)
+		}
+		if !g.Match(input) {
+			t.Errorf("#%d pattern %q should match %q", id, pattern, input)
+		}
+	}
+}

--- a/match/any_of.go
+++ b/match/any_of.go
@@ -58,23 +58,23 @@ func (self AnyOf) Index(s string) (int, []int) {
 }
 
 func (self AnyOf) Len() (l int) {
-	l = -1
-	for _, m := range self.Matchers {
+	if len(self.Matchers) == 0 {
+		return 0
+	}
+
+	// Use an explicit "seen" flag. Previously l started at -1, which is also
+	// the variable-length sentinel, so a leading variable-length alternative
+	// (e.g. Suffix) was treated as "unset" and overwritten by a later fixed
+	// length. That made "{**/x,y}" report a fixed length and get compiled into
+	// a Row that can never match longer prefixes.
+	l = self.Matchers[0].Len()
+	for _, m := range self.Matchers[1:] {
 		ml := m.Len()
-		switch {
-		case l == -1:
-			l = ml
-			continue
-
-		case ml == -1:
-			return -1
-
-		case l != ml:
+		if l == -1 || ml == -1 || l != ml {
 			return -1
 		}
 	}
-
-	return
+	return l
 }
 
 func (self AnyOf) String() string {

--- a/match/any_of_test.go
+++ b/match/any_of_test.go
@@ -51,3 +51,38 @@ func TestAnyOfIndex(t *testing.T) {
 		}
 	}
 }
+
+func TestAnyOfLen(t *testing.T) {
+	for id, test := range []struct {
+		matchers Matchers
+		length   int
+	}{
+		{
+			Matchers{NewText("ab"), NewText("cd")},
+			2,
+		},
+		{
+			Matchers{NewText("ab"), NewText("c")},
+			-1,
+		},
+		{
+			// Leading variable-length alternative must keep Len() == -1
+			// (regression for brace patterns like "{**/x,y}").
+			Matchers{NewSuffix("/daxing"), NewText("daxing")},
+			-1,
+		},
+		{
+			Matchers{NewSuffix("/daxing"), NewText("daxing"), NewText("x")},
+			-1,
+		},
+		{
+			Matchers{NewText("daxing"), NewSuffix("/daxing")},
+			-1,
+		},
+	} {
+		anyOf := NewAnyOf(test.matchers...)
+		if l := anyOf.Len(); l != test.length {
+			t.Errorf("#%d unexpected length: exp: %d, act: %d", id, test.length, l)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Brace patterns with **exactly two** alternatives failed when the first alternative had variable length (e.g. `**/…` → `Suffix`) and the second had fixed length.

```go
input := "playground/daxing/generated/dev.yaml"
glob.Compile("{**/daxing}/**/*dev*.yaml").Match(input)        // true
glob.Compile("{**/daxing,daxing}/**/*dev*.yaml").Match(input) // false (bug)
glob.Compile("{**/daxing,daxing,x}/**/*dev*.yaml").Match(input) // true
```

### Root cause
`AnyOf.Len()` initialized `l = -1` and treated `l == -1` as “not set yet”.  
`-1` is also the **variable-length** sentinel from matchers like `Suffix`/`Super`.  
So a leading variable-length alt was overwritten by a later fixed-length alt, `Len()` returned a fixed size, and `glueMatchersAsRow` built a `Row` that cannot match longer prefixes.

### Fix
Initialize length from the first matcher explicitly and return `-1` as soon as any alternative is variable-length or lengths disagree.

## Test plan
- [x] `go test ./match ./compiler .`
- [x] `TestAnyOfLen` (leading variable-length regression)
- [x] `TestBraceTwoAlternativesWithSuper` (issue repro)

Fixes #66
