### PR TITLE
tail alternatives: match stateless tail alts with a plain loop

### DIFF
--- a/glob_test.go
+++ b/glob_test.go
@@ -1036,6 +1036,55 @@ func BenchmarkCompareGlobAndRegexp(b *testing.B) {
 	}
 }
 
+// TestTailAlts verifies that a tail alternative group with stateless
+// branches compiles into a stateless pattern (see foldTailAlts), while
+// the alts that may need backtracking keep the state.
+func TestTailAlts(t *testing.T) {
+	for _, test := range []struct {
+		pat   string
+		sep   []rune
+		state bool
+	}{
+		{
+			pat: "{abc*def,abc?def,abc[zte]def}",
+		},
+		{
+			pat: "{cat,bat,[fr]at}",
+		},
+		{
+			pat: "{a,}",
+		},
+		{
+			pat: "{*,b}",
+		},
+		{
+			pat: "x{a,{b,c}}",
+		},
+		{
+			pat: "{*.go,*.js}",
+			sep: []rune{'/'},
+		},
+		{
+			// Not a tail alt: something follows it.
+			pat:   "{a,b}c",
+			state: true,
+		},
+		{
+			// A tail alt, but a branch keeps a non-terminal star.
+			pat:   "{a*b*c,d}",
+			state: true,
+		},
+	} {
+		p := MustCompile(test.pat, test.sep...)
+		if p.state != test.state {
+			t.Errorf(
+				"Compile(%q).state = %t; want %t (compiled: %s)",
+				test.pat, p.state, test.state, p.m,
+			)
+		}
+	}
+}
+
 func TestPatternString(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/match.go
+++ b/match.go
@@ -461,6 +461,27 @@ func (ms altMatcher) Match(x matchContext, s string) (int, bool) {
 	return n, match
 }
 
+// tailAltMatcher is a group of alternatives with nothing after it in the
+// pattern and no checkpoint-saving matchers inside: every branch either
+// matches the whole remainder or fails deterministically, so the branches
+// are tried in order with a plain loop -- no checkpoints, no state; see
+// [foldTailAlts]. Rendered with a trailing `$` to tell it from a generic
+// altMatcher in the debug output.
+type tailAltMatcher []matcher
+
+func (ms tailAltMatcher) String() string {
+	return altMatcher(ms).String() + "$"
+}
+
+func (ms tailAltMatcher) Match(x matchContext, s string) (int, bool) {
+	for _, m := range ms {
+		if n, ok := m.Match(x, s); ok && n == len(s) {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
 // textMatcher is a literal, "abc".
 type textMatcher struct {
 	Text string

--- a/parse.go
+++ b/parse.go
@@ -238,6 +238,7 @@ parsing:
 	m := simplify(multiMatcher(stack))
 	m = specialize(m, true)
 	annotateStars(m, true)
+	m = foldTailAlts(m, true)
 	if debug.Enabled {
 		debug.Printf("compiled %#q: %s\n", str, m)
 	}
@@ -580,6 +581,31 @@ func annotateStars(m matcher, tail bool) {
 	}
 }
 
+// foldTailAlts rewrites the tail alts whose branches are all stateless into
+// [tailAltMatcher]s: such a branch either matches the whole remainder or
+// fails, so the alternatives are tried with a plain loop and the alt saves
+// no checkpoints. An alt with a stateful branch (e.g. a non-terminal star
+// inside, as in `{a*b*c,d}`) is left as is.
+//
+// It must run after [annotateStars]: [needsState] reads the Terminal flag
+// it computes.
+func foldTailAlts(m matcher, tail bool) matcher {
+	switch v := m.(type) {
+	case multiMatcher:
+		for i, c := range v {
+			v[i] = foldTailAlts(c, tail && i == len(v)-1)
+		}
+	case altMatcher:
+		for i, c := range v {
+			v[i] = foldTailAlts(c, tail)
+		}
+		if tail && !slices.ContainsFunc(v, needsState) {
+			return tailAltMatcher(v)
+		}
+	}
+	return m
+}
+
 // leadingLiteral returns the literal the given matcher is guaranteed to
 // begin its match with, if any.
 func leadingLiteral(m matcher) string {
@@ -614,6 +640,8 @@ func minLength(m matcher) (n int) {
 			n += minLength(c)
 		}
 		return n
+	case tailAltMatcher:
+		return minLength(altMatcher(v))
 	case altMatcher:
 		n = minLength(v[0])
 		for _, c := range v[1:] {
@@ -635,6 +663,8 @@ func requiredSuffix(m matcher) string {
 		return v.Suffix
 	case multiMatcher:
 		return requiredSuffix(v[len(v)-1])
+	case tailAltMatcher:
+		return requiredSuffix(altMatcher(v))
 	case altMatcher:
 		s := requiredSuffix(v[0])
 		for _, c := range v[1:] {

--- a/readme.md
+++ b/readme.md
@@ -180,9 +180,10 @@ will be much more slower.
 
 `Match` performs zero allocations and is safe for concurrent use. Common
 pattern shapes (literals, prefixes, suffixes, substrings) are recognized at
-compile time and matched with plain string comparisons; the backtracking
-engine behind the rest is differentially fuzzed against the `regexp` package
-(see `FuzzMatchRegexp`).
+compile time and matched with plain string comparisons, and a trailing
+alternative group of such shapes (e.g. `{*.png,*.jpg}`) is tried as a plain
+loop over them; the backtracking engine behind the rest is differentially
+fuzzed against the `regexp` package (see `FuzzMatchRegexp`).
 
 Run `go test -bench=.` from source root to see the benchmarks (the numbers
 below are from an Apple M4):
@@ -193,10 +194,10 @@ Pattern | Fixture | Match | Speed (ns/op)
 `[a-z][!a-x]*cat*[h][!b]*eyes*` | `my dog has very bright eyes` | `false` | 46
 `https://*.google.*` | `https://account.google.com` | `true` | 16
 `https://*.google.*` | `https://google.com` | `false` | 13
-`{https://*.google.*,*yandex.*,*yahoo.*,*mail.ru}` | `http://yahoo.com` | `true` | 61
-`{https://*.google.*,*yandex.*,*yahoo.*,*mail.ru}` | `http://google.com` | `false` | 70
-`{https://*gobwas.com,http://exclude.gobwas.com}` | `https://safe.gobwas.com` | `true` | 24
-`{https://*gobwas.com,http://exclude.gobwas.com}` | `http://safe.gobwas.com` | `false` | 32
+`{https://*.google.*,*yandex.*,*yahoo.*,*mail.ru}` | `http://yahoo.com` | `true` | 21
+`{https://*.google.*,*yandex.*,*yahoo.*,*mail.ru}` | `http://google.com` | `false` | 22
+`{https://*gobwas.com,http://exclude.gobwas.com}` | `https://safe.gobwas.com` | `true` | 7.7
+`{https://*gobwas.com,http://exclude.gobwas.com}` | `http://safe.gobwas.com` | `false` | 8.0
 `google.com` | `google.com` | `true` | 5.0
 `google.com` | `gobwas.com` | `false` | 3.9
 `abc*` | `abcdef` | `true` | 4.1
@@ -219,10 +220,10 @@ Pattern | Fixture | Match | Speed (ns/op) | glob is
 `(?s)^[a-z][^a-x].*cat.*[h][^b].*eyes.*$` | `my dog has very bright eyes` | `false` | 221 | 4.9x faster
 `(?s)^https://.*\.google\..*$` | `https://account.google.com` | `true` | 251 | 16x faster
 `(?s)^https://.*\.google\..*$` | `https://google.com` | `false` | 128 | 9.6x faster
-`(?s)^(https://.*\.google\..*\|.*yandex\..*\|.*yahoo\..*\|.*mail\.ru)$` | `http://yahoo.com` | `true` | 396 | 6.5x faster
-`(?s)^(https://.*\.google\..*\|.*yandex\..*\|.*yahoo\..*\|.*mail\.ru)$` | `http://google.com` | `false` | 558 | 8.0x faster
-`(?s)^(https://.*gobwas\.com\|http://exclude\.gobwas\.com)$` | `https://safe.gobwas.com` | `true` | 210 | 8.8x faster
-`(?s)^(https://.*gobwas\.com\|http://exclude\.gobwas\.com)$` | `http://safe.gobwas.com` | `false` | 46 | 1.4x faster
+`(?s)^(https://.*\.google\..*\|.*yandex\..*\|.*yahoo\..*\|.*mail\.ru)$` | `http://yahoo.com` | `true` | 396 | 19x faster
+`(?s)^(https://.*\.google\..*\|.*yandex\..*\|.*yahoo\..*\|.*mail\.ru)$` | `http://google.com` | `false` | 558 | 25x faster
+`(?s)^(https://.*gobwas\.com\|http://exclude\.gobwas\.com)$` | `https://safe.gobwas.com` | `true` | 210 | 27x faster
+`(?s)^(https://.*gobwas\.com\|http://exclude\.gobwas\.com)$` | `http://safe.gobwas.com` | `false` | 46 | 5.7x faster
 `^google\.com$` | `google.com` | `true` | 25 | 5.0x faster
 `^google\.com$` | `gobwas.com` | `false` | 17 | 4.3x faster
 `(?s)^abc.*$` | `abcdef` | `true` | 43 | 10x faster


### PR DESCRIPTION
A tail alternatives whose branches are all stateless can never be resumed: each branch either matches the whole remainder or fails deterministically. Fold such alts into tailAltMatcher -- the branches are tried in order with no checkpoints and no matchState, so e.g. {abc*def,abc?def,abc[zte]def} now matches without touching the state pool at all.

Alternative-heavy benchmarks improve 65-75% (24ns -> 8ns on the shaped ones, 61ns -> 21ns on the four-branch row); patterns with stateful branches ({a*b*c,d}) or non-tail alts ({a,b}c) are unchanged.